### PR TITLE
#10_1: State Reducer (custom reducer) 

### DIFF
--- a/showcase/src/patterns/usage.css
+++ b/showcase/src/patterns/usage.css
@@ -31,6 +31,7 @@
     outline: 0;
     display: block;
     width: 100%;
+    cursor: pointer;
 }
 .resetMsg {
     color: black;


### PR DESCRIPTION
## What is this PR about? 🤔
Allow user pass in their custom reducer as opposed to the internal reducer being used for state management

## Changes 🎁

- [x] Passed in a user-defined reducer

## Before/After 📸
https://advanced-react-patterns-ultrasimplified.netlify.com/state-reducers

## Other comments 💬
- A quick look at the implementation shows the downside to this: the repetitive logic the user has to re-implement.

Next PR 👉https://github.com/ohansemmanuel/advanced-react-patterns-ultrasimplified/pull/14